### PR TITLE
Punctuation long pauses fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ htmlcov
 /download/
 /cmake/
 /_install/
+/install/

--- a/src/phonemize.cpp
+++ b/src/phonemize.cpp
@@ -115,13 +115,10 @@ phonemize_eSpeak(std::string text, eSpeakPhonemeConfig &config,
       sentencePhonemes->push_back(config.exclamation);
     } else if (punctuation == CLAUSE_COMMA) {
       sentencePhonemes->push_back(config.comma);
-      sentencePhonemes->push_back(config.space);
     } else if (punctuation == CLAUSE_COLON) {
       sentencePhonemes->push_back(config.colon);
-      sentencePhonemes->push_back(config.space);
     } else if (punctuation == CLAUSE_SEMICOLON) {
       sentencePhonemes->push_back(config.semicolon);
-      sentencePhonemes->push_back(config.space);
     }
 
     if ((terminator & CLAUSE_TYPE_SENTENCE) == CLAUSE_TYPE_SENTENCE) {

--- a/src/test.cpp
+++ b/src/test.cpp
@@ -89,7 +89,7 @@ int main(int argc, char *argv[]) {
   piper::phonemize_eSpeak("this, is: a; test.", phonemeConfig, phonemes);
 
   std::string phonemeStr = phonemeString(phonemes);
-  if (phonemeStr != "ðˈɪs, ɪz: ˈeɪ; tˈɛst.\n") {
+  if (phonemeStr != "ðˈɪs,ɪz:ˈeɪ;tˈɛst.\n") {
     std::cerr << "punctuation test: " << phonemeStr << std::endl;
     return 1;
   }


### PR DESCRIPTION
Currently phonemizer adds space phoneme after every comma, colon & semicolon. As a result it skews the duration of these phonemes resulting in unnatural voicing.
Removing these spaces to get back to natural sound. Also, piper has a way to control pause duration after each phoneme via  model inference phoneme silence parameters.

So this change results in cleaner and more controllable voicing.

```
"inference": {
  "phoneme_silence": {
    "<phoneme>": <seconds of silence>,
    ...
}
``` 